### PR TITLE
비밀번호 변경 리팩토링 및 회원탈퇴 기능 개발 완료

### DIFF
--- a/src/main/java/com/innovation/assignment/config/AsyncConfig.java
+++ b/src/main/java/com/innovation/assignment/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.innovation.assignment.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/innovation/assignment/customer/application/dto/request/CreateCustomerRequestDto.java
+++ b/src/main/java/com/innovation/assignment/customer/application/dto/request/CreateCustomerRequestDto.java
@@ -1,4 +1,4 @@
-package com.innovation.assignment.customer.application.dto;
+package com.innovation.assignment.customer.application.dto.request;
 
 import com.innovation.assignment.customer.domain.entity.Customer;
 import com.innovation.assignment.customer.domain.vo.*;

--- a/src/main/java/com/innovation/assignment/customer/application/event/CustomerEventListener.java
+++ b/src/main/java/com/innovation/assignment/customer/application/event/CustomerEventListener.java
@@ -1,0 +1,20 @@
+package com.innovation.assignment.customer.application.event;
+
+import com.innovation.assignment.customer.application.service.CustomerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomerEventListener {
+
+    private final CustomerService customerService;
+
+    @Async
+    @EventListener
+    public void onCustomerHasDeletedEvent(CustomerHasDeletedEvent customerHasDeletedEvent) {
+        customerService.addCustomerHistory(customerHasDeletedEvent.getDeleteCustomerRequestDto());
+    }
+}

--- a/src/main/java/com/innovation/assignment/customer/application/event/CustomerHasDeletedEvent.java
+++ b/src/main/java/com/innovation/assignment/customer/application/event/CustomerHasDeletedEvent.java
@@ -1,0 +1,12 @@
+package com.innovation.assignment.customer.application.event;
+
+import com.innovation.assignment.customer.presentation.dto.request.DeleteCustomerRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomerHasDeletedEvent {
+
+    private DeleteCustomerRequestDto deleteCustomerRequestDto;
+}

--- a/src/main/java/com/innovation/assignment/customer/domain/entity/Customer.java
+++ b/src/main/java/com/innovation/assignment/customer/domain/entity/Customer.java
@@ -67,4 +67,8 @@ public class Customer {
         this.phone = phone;
         this.address = address;
     }
+
+    public void changePassword(Password newPassword, PasswordEncoder passwordEncoder) {
+        this.password = password.changePassword(newPassword, passwordEncoder);
+    }
 }

--- a/src/main/java/com/innovation/assignment/customer/domain/entity/CustomerHistory.java
+++ b/src/main/java/com/innovation/assignment/customer/domain/entity/CustomerHistory.java
@@ -1,0 +1,30 @@
+package com.innovation.assignment.customer.domain.entity;
+
+import com.innovation.assignment.customer.domain.vo.WithdrawalReason;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private Long customerId;
+
+    @Embedded
+    private WithdrawalReason withdrawalReason;
+
+    private CustomerHistory(Long customerId, WithdrawalReason withdrawalReason) {
+        this.customerId = customerId;
+        this.withdrawalReason = withdrawalReason;
+    }
+
+    public static CustomerHistory createCustomerHistory(Long customerId, WithdrawalReason withdrawalReason) {
+        return new CustomerHistory(customerId, withdrawalReason);
+    }
+}

--- a/src/main/java/com/innovation/assignment/customer/domain/repository/CustomerHistoryRepository.java
+++ b/src/main/java/com/innovation/assignment/customer/domain/repository/CustomerHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.innovation.assignment.customer.domain.repository;
+
+import com.innovation.assignment.customer.domain.entity.CustomerHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerHistoryRepository extends JpaRepository<CustomerHistory, Long> {
+}

--- a/src/main/java/com/innovation/assignment/customer/domain/vo/Password.java
+++ b/src/main/java/com/innovation/assignment/customer/domain/vo/Password.java
@@ -1,5 +1,6 @@
 package com.innovation.assignment.customer.domain.vo;
 
+import com.innovation.assignment.exception.exception.customer.SamePasswordException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,5 +27,17 @@ public class Password {
 
     public Password encodedPassword(PasswordEncoder passwordEncoder) {
         return new Password(passwordEncoder.encode(password));
+    }
+
+    public Password changePassword(Password newPassword, PasswordEncoder passwordEncoder) {
+        
+        if (isMatchesCurrentPassword(newPassword, passwordEncoder)) {
+            throw new SamePasswordException();
+        }
+        return newPassword.encodedPassword(passwordEncoder);
+    }
+
+    private boolean isMatchesCurrentPassword(Password newPassword, PasswordEncoder passwordEncoder) {
+        return passwordEncoder.matches(newPassword.password, this.password);
     }
 }

--- a/src/main/java/com/innovation/assignment/customer/domain/vo/WithdrawalReason.java
+++ b/src/main/java/com/innovation/assignment/customer/domain/vo/WithdrawalReason.java
@@ -1,0 +1,18 @@
+package com.innovation.assignment.customer.domain.vo;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+public class WithdrawalReason {
+
+    private final String WithdrawalReason;
+
+    private WithdrawalReason(String withdrawalReason) {
+        WithdrawalReason = withdrawalReason;
+    }
+
+    public static WithdrawalReason of(String withdrawalReason) {
+        return new WithdrawalReason(withdrawalReason);
+    }
+}

--- a/src/main/java/com/innovation/assignment/customer/infrastructure/dto/response/GetCustomerResponseDto.java
+++ b/src/main/java/com/innovation/assignment/customer/infrastructure/dto/response/GetCustomerResponseDto.java
@@ -1,4 +1,4 @@
-package com.innovation.assignment.customer.infrastructure.dto;
+package com.innovation.assignment.customer.infrastructure.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/innovation/assignment/customer/infrastructure/repository/CustomerQueryRepository.java
+++ b/src/main/java/com/innovation/assignment/customer/infrastructure/repository/CustomerQueryRepository.java
@@ -3,7 +3,7 @@ package com.innovation.assignment.customer.infrastructure.repository;
 import com.innovation.assignment.customer.domain.entity.Customer;
 import com.innovation.assignment.customer.domain.vo.Email;
 import com.innovation.assignment.customer.domain.vo.Phone;
-import com.innovation.assignment.customer.infrastructure.dto.GetCustomerResponseDto;
+import com.innovation.assignment.customer.infrastructure.dto.response.GetCustomerResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/innovation/assignment/customer/infrastructure/repository/CustomerQueryRepositoryImpl.java
+++ b/src/main/java/com/innovation/assignment/customer/infrastructure/repository/CustomerQueryRepositoryImpl.java
@@ -4,7 +4,7 @@ import com.innovation.assignment.customer.domain.entity.Customer;
 import com.innovation.assignment.customer.domain.entity.QCustomer;
 import com.innovation.assignment.customer.domain.vo.Email;
 import com.innovation.assignment.customer.domain.vo.Phone;
-import com.innovation.assignment.customer.infrastructure.dto.GetCustomerResponseDto;
+import com.innovation.assignment.customer.infrastructure.dto.response.GetCustomerResponseDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/innovation/assignment/customer/presentation/controller/CustomerRestController.java
+++ b/src/main/java/com/innovation/assignment/customer/presentation/controller/CustomerRestController.java
@@ -1,12 +1,9 @@
 package com.innovation.assignment.customer.presentation.controller;
 
-import com.innovation.assignment.customer.application.dto.CreateCustomerRequestDto;
+import com.innovation.assignment.customer.application.dto.request.CreateCustomerRequestDto;
 import com.innovation.assignment.customer.application.service.CustomerService;
-import com.innovation.assignment.customer.infrastructure.dto.GetCustomerResponseDto;
-import com.innovation.assignment.customer.presentation.dto.ChangeCustomerInfoRequestDto;
-import com.innovation.assignment.customer.presentation.dto.ChangePasswordRequestDto;
-import com.innovation.assignment.customer.presentation.dto.SearchCustomerByEmailRequestDto;
-import com.innovation.assignment.customer.presentation.dto.SearchCustomerByPhoneRequestDto;
+import com.innovation.assignment.customer.infrastructure.dto.response.GetCustomerResponseDto;
+import com.innovation.assignment.customer.presentation.dto.request.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -68,6 +65,14 @@ public class CustomerRestController {
             @RequestBody ChangeCustomerInfoRequestDto changeCustomerInfoRequestDto
     ) {
         customerService.changeCustomerInfo(changeCustomerInfoRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteCustomer(
+            @RequestBody DeleteCustomerRequestDto deleteCustomerRequestDto
+    ) {
+        customerService.deleteCustomer(deleteCustomerRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/innovation/assignment/customer/presentation/dto/request/ChangeCustomerInfoRequestDto.java
+++ b/src/main/java/com/innovation/assignment/customer/presentation/dto/request/ChangeCustomerInfoRequestDto.java
@@ -1,4 +1,4 @@
-package com.innovation.assignment.customer.presentation.dto;
+package com.innovation.assignment.customer.presentation.dto.request;
 
 public record ChangeCustomerInfoRequestDto(
         Long customerId,

--- a/src/main/java/com/innovation/assignment/customer/presentation/dto/request/ChangePasswordRequestDto.java
+++ b/src/main/java/com/innovation/assignment/customer/presentation/dto/request/ChangePasswordRequestDto.java
@@ -1,4 +1,4 @@
-package com.innovation.assignment.customer.presentation.dto;
+package com.innovation.assignment.customer.presentation.dto.request;
 
 public record ChangePasswordRequestDto(
         Long customerId,

--- a/src/main/java/com/innovation/assignment/customer/presentation/dto/request/DeleteCustomerRequestDto.java
+++ b/src/main/java/com/innovation/assignment/customer/presentation/dto/request/DeleteCustomerRequestDto.java
@@ -1,0 +1,7 @@
+package com.innovation.assignment.customer.presentation.dto.request;
+
+public record DeleteCustomerRequestDto(
+        Long customerId,
+        String withdrawalReason
+) {
+}

--- a/src/main/java/com/innovation/assignment/customer/presentation/dto/request/SearchCustomerByEmailRequestDto.java
+++ b/src/main/java/com/innovation/assignment/customer/presentation/dto/request/SearchCustomerByEmailRequestDto.java
@@ -1,4 +1,4 @@
-package com.innovation.assignment.customer.presentation.dto;
+package com.innovation.assignment.customer.presentation.dto.request;
 
 public record SearchCustomerByEmailRequestDto(
         String email

--- a/src/main/java/com/innovation/assignment/customer/presentation/dto/request/SearchCustomerByPhoneRequestDto.java
+++ b/src/main/java/com/innovation/assignment/customer/presentation/dto/request/SearchCustomerByPhoneRequestDto.java
@@ -1,4 +1,4 @@
-package com.innovation.assignment.customer.presentation.dto;
+package com.innovation.assignment.customer.presentation.dto.request;
 
 public record SearchCustomerByPhoneRequestDto(
         String phone

--- a/src/main/java/com/innovation/assignment/exception/ErrorCode.java
+++ b/src/main/java/com/innovation/assignment/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     EMPTY_CUSTOMER_LIST("고객 목록이 비어있습니다."),
     CUSTOMER_NOT_FOUND("고객을 찾을 수 없습니다."),
     PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다."),
-    PASSWORD_CONFIRMATION_MISMATCH("변경할 비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+    PASSWORD_CONFIRMATION_MISMATCH("변경할 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    SAME_PASSWORD("기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.");
 
     private final String message;
 

--- a/src/main/java/com/innovation/assignment/exception/exception/customer/DuplicatePhoneException.java
+++ b/src/main/java/com/innovation/assignment/exception/exception/customer/DuplicatePhoneException.java
@@ -1,4 +1,4 @@
-package com.innovation.assignment.exception.exception;
+package com.innovation.assignment.exception.exception.customer;
 
 import com.innovation.assignment.exception.ApplicationException;
 import com.innovation.assignment.exception.ErrorCode;

--- a/src/main/java/com/innovation/assignment/exception/exception/customer/SamePasswordException.java
+++ b/src/main/java/com/innovation/assignment/exception/exception/customer/SamePasswordException.java
@@ -1,0 +1,12 @@
+package com.innovation.assignment.exception.exception.customer;
+
+import com.innovation.assignment.exception.ApplicationException;
+import com.innovation.assignment.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class SamePasswordException extends ApplicationException {
+
+    public SamePasswordException() {
+        super(HttpStatus.BAD_REQUEST, ErrorCode.SAME_PASSWORD, ErrorCode.SAME_PASSWORD.getMessage());
+    }
+}

--- a/src/test/java/com/innovation/assignment/customer/application/service/CustomerServiceTest.java
+++ b/src/test/java/com/innovation/assignment/customer/application/service/CustomerServiceTest.java
@@ -1,14 +1,14 @@
 package com.innovation.assignment.customer.application.service;
 
-import com.innovation.assignment.exception.exception.DuplicatePhoneException;
+import com.innovation.assignment.exception.exception.customer.DuplicatePhoneException;
 import com.innovation.assignment.exception.exception.customer.DuplicateEmailException;
 import com.innovation.assignment.exception.exception.customer.EmptyCustomerListException;
 import com.innovation.assignment.exception.exception.customer.CustomerNotFoundException;
-import com.innovation.assignment.customer.application.dto.CreateCustomerRequestDto;
+import com.innovation.assignment.customer.application.dto.request.CreateCustomerRequestDto;
 import com.innovation.assignment.customer.domain.repository.CustomerRepository;
-import com.innovation.assignment.customer.infrastructure.dto.GetCustomerResponseDto;
-import com.innovation.assignment.customer.presentation.dto.SearchCustomerByEmailRequestDto;
-import com.innovation.assignment.customer.presentation.dto.SearchCustomerByPhoneRequestDto;
+import com.innovation.assignment.customer.infrastructure.dto.response.GetCustomerResponseDto;
+import com.innovation.assignment.customer.presentation.dto.request.SearchCustomerByEmailRequestDto;
+import com.innovation.assignment.customer.presentation.dto.request.SearchCustomerByPhoneRequestDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -218,4 +218,10 @@ class CustomerServiceTest {
         assertThat(customerInfo).isNotNull();
         assertThat(customerInfo.getId()).isEqualTo(1L);
     }
+    //TODO 비밀번호 변경 -> 기존 비밀번호와 같은 문자열로 변경 시도시 예외 발생
+    //TODO 비밀번호 변경 -> 변결할 비밀번호와 비밀번호 확인이 서로 일치하지 않을때 예외 발생
+    //TODO 비밀번호 변경 -> 비밀번호 검증이 끝나면 비밀번호 변경
+    //TODO 고객정보 삭제 -> 해당 식별자를 가진 고객이 없을 경우 예외 발생
+    //TODO 고객정보 삭제 -> 고객 정보가 존재할 경우 고객 정보 삭제
+    //TODO 고객정보 삭제 -> 삭제된 고객 히스토리 생성 여부 검증
 }


### PR DESCRIPTION
### 비밀번호 변경 리팩토링
- update 쿼리를 직접 사용 -> 더티 체킹을 활용한 업데이트
- 기존 비밀번호와 새 비밀번호가 일치하는지 검증

### 회원 탈퇴
- 입력한 식별자를 가진 고객 정보 삭제
- 회원 탈퇴 이유 히스토리에 저장